### PR TITLE
Changed indent size from 2 to 4, as discussed in a previous meeting.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
As discussed previously we wanted an indent size of 4 and this was just a misconfiguration. If we want any other code style rules in this files then this would probably be a good time to do so.

Short summary: .editorconfig is a file that IDEs can use to set their rules for (automatic) code formatting. Most editors read this file natively and in will use it by default. Other editors need to be setup manually or require a plugin to use. For a full overview see: http://editorconfig.org/

After this branch has been merged the branch can be deleted since there is no further use.