### PR TITLE
Fixes transparency of the visualization settings button.

### DIFF
--- a/src/assets/scss/modules/_visualization-settings-button.scss
+++ b/src/assets/scss/modules/_visualization-settings-button.scss
@@ -3,6 +3,7 @@
   position: absolute;
   right: 2rem;
   bottom: 2rem;
+  background-color: rgba(255,255,255,0.7);
 }
 
 .settings-button-form {


### PR DESCRIPTION
The button used to be completely transparent, now its like this:
![image](https://user-images.githubusercontent.com/17181862/40128263-76fa91b0-5931-11e8-8947-2281ae6a438b.png)

Fixes #91 