### PR TITLE
Hotfix/default values slider

### DIFF
--- a/src/form/form-builder.ts
+++ b/src/form/form-builder.ts
@@ -38,7 +38,7 @@ export class FormBuilder {
     }
 
     public addSliderField(name: string, defaultValue: number, options: SliderFormOptions): FormBuilder {
-        this.addField(name, FormType.Slider, String(defaultValue), options);
+        this.addField(name, FormType.Slider, defaultValue, options);
 
         return this;
     }


### PR DESCRIPTION
Fixes #85. For some reason, the value is not reflected correctly to the slider element. Angular internally holds the correct value, so we just re-patch the value and then everything works. Not a nice fix, but hey, it works :)