### PR TITLE
Fix firefox range slider issue

### DIFF
--- a/src/assets/scss/modules/_visualization-settings-button.scss
+++ b/src/assets/scss/modules/_visualization-settings-button.scss
@@ -28,5 +28,10 @@
     border-width: 8px 12.5px 0 12.5px;
     border-color: rgba(0, 0, 0, .2) transparent transparent transparent;
   }
+
+  // fix for firefox range input offset
+  input {
+    margin: 0 2px;
+  }
 }
 /** @end-author Bart Wesselink */


### PR DESCRIPTION
Fixes #155 
On Firefox the range slider in the visualization settings was not aligned properly. I think the default margin for sliders differs between Chrome and Firefox, this overwrites that. 
develop:
![image](https://user-images.githubusercontent.com/17181862/40885933-d71571da-672f-11e8-88a4-385267d77bda.png)
feature/viz-slider:
![image](https://user-images.githubusercontent.com/17181862/40885928-cd47eb9c-672f-11e8-9120-87f28ee64660.png)
