### PR TITLE
Use gradients in the basic tree viz

### DIFF
--- a/src/visualizations/basic-tree.ts
+++ b/src/visualizations/basic-tree.ts
@@ -6,6 +6,7 @@ import {Draw} from '../interfaces/draw';
 import {VisualizerInput} from '../interfaces/visualizer-input';
 import {ShaderMode} from "../opengl/shaders/shaderMode";
 import {OpenGL} from "../opengl/opengl";
+import {Palette} from "../models/palette";
 
 /** @author Mathijs Boezer */
 export class BasicTree implements Visualizer {
@@ -117,23 +118,23 @@ export class BasicTree implements Visualizer {
     /** @end-author Mathijs Boezer */
     /** @author Roan Hofland */
     public updateColors(gl: OpenGL, input: VisualizerInput, draws: Draw[]): void{
-        this.recolor(input.tree, gl, draws, input.tree.selected);
+        this.recolor(input.tree, input.palette, gl, draws, input.tree.selected);
         for(var i = input.tree.subTreeSize; i < draws.length; i++){
             gl.copyColor(draws[draws[i].linked].glid, draws[i].glid);
         }
     }
-    
-    private recolor(tree: Node, gl: OpenGL, draws: Draw[], selected: boolean){
+
+    private recolor(tree: Node, palette: Palette, gl: OpenGL, draws: Draw[], selected: boolean){
         if(draws[tree.identifier].type == 10){
             if (selected || tree.selected) {
                 selected = true;
-                gl.setColor(draws[tree.identifier].glid, [0, 0, 0]);
+                gl.setColor(draws[tree.identifier].glid, palette.gradientColorMapSelected[tree.maxDepth][tree.depth]);
             } else {
-                gl.setColor(draws[tree.identifier].glid, [0.4, 0.4, 0.4]);
+                gl.setColor(draws[tree.identifier].glid, palette.gradientColorMap[tree.maxDepth][tree.depth]);
             }
         }
         for(let child of tree.children){
-            this.recolor(child, gl, draws, selected);
+            this.recolor(child, palette, gl, draws, selected);
         }
     }
     /** @end-author Roan Hofland */


### PR DESCRIPTION
Implements the new color gradients in the basic tree.
develop:
![screenshot-2018-06-17t13_29_04 695z](https://user-images.githubusercontent.com/17181862/41508321-2da36822-7243-11e8-805e-68741b26248b.png)
feature/basic-tree-colors
![screenshot-2018-06-17t13_28_48 609z](https://user-images.githubusercontent.com/17181862/41508322-2f2467aa-7243-11e8-8b8f-cc5ba9332e85.png)
