### PR TITLE
Add 4 high value-range colors.

### DIFF
--- a/src/components/general-settings-button/general-settings-button.component.ts
+++ b/src/components/general-settings-button/general-settings-button.component.ts
@@ -70,7 +70,7 @@ export class GeneralSettingsButtonComponent implements OnInit {
                         longRed: 'Min-max Red',
                         longGreen: 'Min-max Green',
                         longBlue: 'Min-max Blue',
-                        longGrey: 'Min-max Grey',
+                        longGrey: 'Min-max Greyscale',
                         redBlue: 'Red and Blue',
                         greyScale: 'Greyscale',
                         vaporWave: 'Vaporwave',

--- a/src/components/window/window.component.ts
+++ b/src/components/window/window.component.ts
@@ -547,7 +547,7 @@ export class WindowComponent implements OnInit {
 
     private readSettings(settings: Settings, initialize: boolean): void {
         if (!settings.colorMode) {
-            this.palette = Palettes.greyScale;
+            this.palette = Palettes.longGrey;
         } else {
             this.palette = this.getPalette(settings.palette);
         }

--- a/src/utils/palettes.ts
+++ b/src/utils/palettes.ts
@@ -21,7 +21,7 @@ export class Palettes {
         ]
     );
     static greyScale = new Palette(
-        Color.fromHex('0D0D0D'),
+        Color.fromHex('4D4D4D'),
         Color.fromHex('D9D9D9'),
         [
             Color.fromHex('595959'),


### PR DESCRIPTION
Monochrome gradients where only value changes works well for people who suffer from color deficiency. Hence this adds a few palettes which are guaranteed to work for them. (Most notably the `Min-max greyscale`.)
# Changes
- nieuwe palettes die monochroom zijn met een een hoge maxvalue en lage minvalue zodat het contrast/de color range zo groot mogelijk is op de lineaire gradient.
- `greyScale` iets minder donker gemaakt, dan is hij wat meer distinct van de `Min-max greyScale`
- `NGL (Blue)` renamed naar `NGL Blue`. We claimen die blauw gewoon en hangen onze naam er aan.
- `Min-max greyScale` is nu de default voor `colorMode == false`
# Nieuwe palettes
![image](https://user-images.githubusercontent.com/5939851/41614031-9f4260f4-73f7-11e8-9de6-f3ff4bfab9b5.png)
![image](https://user-images.githubusercontent.com/5939851/41614043-aa833dbc-73f7-11e8-8419-bbd73468a865.png)
![image](https://user-images.githubusercontent.com/5939851/41614072-bad046f6-73f7-11e8-9166-65c02b23a220.png)
![image](https://user-images.githubusercontent.com/5939851/41614083-c54c6808-73f7-11e8-8b0a-95df20ccc8e8.png)
## Aangepaste greyScale
![image](https://user-images.githubusercontent.com/5939851/41614304-751108b6-73f8-11e8-8244-d9c2970f6841.png)
