### PR TITLE
Fix color calculation of selected sub-tree

### DIFF
--- a/src/models/palette.ts
+++ b/src/models/palette.ts
@@ -136,7 +136,7 @@ export class Palette {
     }
 
     private calcLinearRGBGradient(depth: number, selectedDepth: number, maxDepth: number): number[] {
-        let percent: number = ((depth - selectedDepth) / maxDepth);
+        let percent: number = ((depth - selectedDepth) / (maxDepth - selectedDepth));
         let red: number = this.primary.r - percent * (this.primary.r - this.secondary.r);
         let green: number = this.primary.g - percent * (this.primary.g - this.secondary.g);
         let blue: number = this.primary.b - percent * (this.primary.b - this.secondary.b);
@@ -162,7 +162,7 @@ export class Palette {
             delta = d + ((Math.abs(d) < 180) ? ((d < 0) ? 360 : -360) : 0);
         }
         for (let i = 0; i <= maxDepth; i++) {
-            percent = (i - selectedDepth) / maxDepth;
+            percent = (i - selectedDepth) / (maxDepth - selectedDepth);
             hueValues.push(((this.primary.h + (delta * percent) + 360) % 360) / 360);
             satValues.push(this.primary.s - (this.primary.s - this.secondary.s) * percent);
             valValues.push(this.primary.v - (this.primary.v - this.secondary.v) * percent);


### PR DESCRIPTION
Colors of selected sub-trees now calculate correctly >:)
![image](https://user-images.githubusercontent.com/25138418/41662691-f5d737a0-74a1-11e8-85e4-ae98170d76b8.png)
![image](https://user-images.githubusercontent.com/25138418/41662713-fe1dabc4-74a1-11e8-9a8b-aef7b59cbabf.png)
