### PR TITLE
Create .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ cache:
 stages:
    - build
 
-compile:
+build:
   script:
     - yarn install
     - yarn build


### PR DESCRIPTION
Alternative CI since we ran out of CircleCI quota. This one is linked to my GitLab account since unfortunatally I couldn't link my own server, which would've been infinite minutes, however I still have 2000 GitLab minutes left this month.

The only left to do is for Bart to configure the relevant webhook (for which I sent the details via Telegram) and to disable CircleCI.