### PR TITLE
Fix subtree interaction errors

### DIFF
--- a/src/utils/interaction-handler.ts
+++ b/src/utils/interaction-handler.ts
@@ -29,7 +29,7 @@ export class InteractionHandler {
         for (let i = draws.length - 1; i >= 0; i--) {
             const draw: Draw = draws[i];
 
-            if (draw.identifier != undefined && gl.isShapeVisible(draw.glid) && this.withinDraw(draw, x, y)) {
+            if (draw != undefined && draw.identifier != undefined && gl.isShapeVisible(draw.glid) && this.withinDraw(draw, x, y)) {
                 return this.findNodeByIdentifier(tree, draw.identifier);
             }
         }


### PR DESCRIPTION
Draws can be null if a subtree is renderered with the original tree data so we just add a check for that.

fixes #249 