### PR TITLE
Transformations resetting too often

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -369,6 +369,7 @@ export class AppComponent implements OnInit {
         }
         for (const tab of this.tabs) {
             tab.window.computing = true;
+            tab.window.resetTransformation();
         }
 
         // reset selection on old tree

--- a/src/components/window/window.component.ts
+++ b/src/components/window/window.component.ts
@@ -379,8 +379,6 @@ export class WindowComponent implements OnInit {
 
                         this.currentDraws = draws;
                         this.computing = false;
-
-                        this.resetTransformation();
                         this.showModal = false;
                         resolve();
                     });


### PR DESCRIPTION
Only reset the viewport transformation when opening a new tree and now when for example changing the visualisation settings.