### PR TITLE
Update the selectBus selectedNode to the new root, then things functi…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -98,6 +98,7 @@ export class AppComponent implements OnInit {
         });
 
         this.subtreeBus.subtreeSelected.subscribe((node: Node) => {
+            this.selectBus.selectNode(node);
             this.openTree(node);
         });
 


### PR DESCRIPTION
Update the selectBus selectedNode to the new root when a subtree is opened as a new main tree. With this things function properly again. This bug was only apparent when using the `zoom and pan` interaction mode.

fixes #269 

Nevermind the branchname, I initially thought the issue was coming from some other logic.