### PR TITLE
Reorder example datasets

### DIFF
--- a/src/providers/dataset-storage-service.ts
+++ b/src/providers/dataset-storage-service.ts
@@ -17,8 +17,8 @@ export class DatasetStorageService {
     private userDatasetsStorageKey = 'userDatasets';
 
     public defaultDatasets: DatasetFile[] = [
-        {title: 'NCBI Dataset', path: this.defaultDataPath + 'ncbi-taxonomy.tre'},
         {title: 'Phyloviz example dataset', path: this.defaultDataPath + 'newick_example_phyloviz.nwk'},
+        {title: 'NCBI Dataset', path: this.defaultDataPath + 'ncbi-taxonomy.tre'},
         {title: 'Galaxy Dataset', path: this.defaultDataPath + 'galaxy.tre'},
         {title: 'Expected phylogeny of last generation of isolates', path: this.defaultDataPath + 'ideal_lastday.newick'},
         {title: 'Tetrapoda Chronograms', path: this.defaultDataPath + 'tetrapoda chronograms.tre'},


### PR DESCRIPTION
Due to the changing of the ordering of the datasets the help tour now uses the NCBI dataset. This is obviously a bad idea since it is quite heavy, and there are references to Phyloviz dataset in the help tour.
This swaps them back like they were ordered before #274 and #275.