### PR TITLE
Fix webserver requirement

### DIFF
--- a/src/providers/dataset-storage-service.ts
+++ b/src/providers/dataset-storage-service.ts
@@ -12,7 +12,7 @@ declare var importScripts;
 @Injectable()
 export class DatasetStorageService {
     /** @author Mathijs Boezer */
-    private defaultDataPath = '/assets/default-data/';
+    private defaultDataPath = 'assets/default-data/';
     private pakoDataPath = 'assets/scripts/pako.js'; // no slash because document.location.href already has one at the end
     private userDatasetsStorageKey = 'userDatasets';
 

--- a/src/visualizations/basic-tree.ts
+++ b/src/visualizations/basic-tree.ts
@@ -105,7 +105,7 @@ export class BasicTree implements Visualizer {
     }
 
     public getThumbnailImage(): string|null {
-        return '/assets/images/visualization-basic-tree.png';
+        return 'assets/images/visualization-basic-tree.png';
     }
 
     public enableShaders(gl: OpenGL): void {

--- a/src/visualizations/circles.ts
+++ b/src/visualizations/circles.ts
@@ -217,7 +217,7 @@ export class Circles implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-circular-tree-map.png';
+        return 'assets/images/visualization-circular-tree-map.png';
     }
 
     public enableShaders(gl: OpenGL): void {

--- a/src/visualizations/galaxy.ts
+++ b/src/visualizations/galaxy.ts
@@ -72,7 +72,7 @@ export class Galaxy implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-galaxy.png';
+        return 'assets/images/visualization-galaxy.png';
     }
 
     public enableShaders(gl: OpenGL): void {

--- a/src/visualizations/generalized-pythagoras-tree.ts
+++ b/src/visualizations/generalized-pythagoras-tree.ts
@@ -136,7 +136,7 @@ export class GeneralizedPythagorasTree implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-generalized-pythagoras-tree.png';
+        return 'assets/images/visualization-generalized-pythagoras-tree.png';
     }
     /** @end-author Jules Cornelissen */
     /** @author Roan Hofland */

--- a/src/visualizations/icicle-plot.ts
+++ b/src/visualizations/icicle-plot.ts
@@ -138,7 +138,7 @@ export class IciclePlot implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-icicle-plot.png';
+        return 'assets/images/visualization-icicle-plot.png';
     }
     /** @end-author Nico Klaassen */
     /** @author Roan Hofland */

--- a/src/visualizations/opengl-demo-tree.ts
+++ b/src/visualizations/opengl-demo-tree.ts
@@ -157,7 +157,7 @@ export class OpenglDemoTree implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/opengl-demo-tree.png';
+        return 'assets/images/opengl-demo-tree.png';
     }
 
     public enableShaders(gl: OpenGL): void {

--- a/src/visualizations/simple-tree-map.ts
+++ b/src/visualizations/simple-tree-map.ts
@@ -171,7 +171,7 @@ export class SimpleTreeMap implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-simple-tree-map.png';
+        return 'assets/images/visualization-simple-tree-map.png';
     }
 
     public enableShaders(gl: OpenGL): void {

--- a/src/visualizations/space-reclaiming-stack.ts
+++ b/src/visualizations/space-reclaiming-stack.ts
@@ -167,7 +167,7 @@ export class SpaceReclaimingStack implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-space-reclaiming-stack.png';
+        return 'assets/images/visualization-space-reclaiming-stack.png';
     }
 
     public enableShaders(gl: OpenGL):void {

--- a/src/visualizations/sunburst.ts
+++ b/src/visualizations/sunburst.ts
@@ -80,7 +80,7 @@ export class Sunburst implements Visualizer {
     }
 
     public getThumbnailImage(): string | null {
-        return '/assets/images/visualization-sunburst.png';
+        return 'assets/images/visualization-sunburst.png';
     }
 
     public enableShaders(gl: OpenGL): void {


### PR DESCRIPTION
Removes the first slash for all assets locations. This removes the requirement for a website and allows the users to just open index.html to run the tool after it was built using yarn.